### PR TITLE
Using MSBuild to build package rather than Visual Studio

### DIFF
--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -13,7 +13,7 @@ end
 
 powershell_script "build-solution" do
     code <<-EOH
-        & "C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\msbuild.exe" ScriptServices.sln 
+        & "C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\msbuild.exe" ScriptServices.sln /t:go /fl /flp:logFile=ScriptServices.build.log
     EOH
     cwd src_dir
 end

--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -13,7 +13,7 @@ end
 
 powershell_script "build-solution" do
     code <<-EOH
-        & "C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\msbuild.exe" ScriptServices.sln /t:go /fl /flp:logFile=ScriptServices.build.log
+        & "C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\msbuild.exe" ScriptServices.sln /fl /flp:logFile=ScriptServices.build.log
     EOH
     cwd src_dir
 end

--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -13,7 +13,7 @@ end
 
 powershell_script "build-solution" do
     code <<-EOH
-        & "C:/Program Files (x86)/Microsoft Visual Studio 14.0/Common7/IDE/devenv.exe" ScriptServices.sln /Build debug /Out log.txt
+        & "C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\msbuild.exe" ScriptServices.sln 
     EOH
     cwd src_dir
 end

--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -6,13 +6,6 @@
 
 src_dir = File.expand_path("#{node['delivery']['workspace']['repo']}/src")
 
-powershell_script "clean-workspace" do
-    code <<-EOH
-        & "C:/Program Files (x86)/Microsoft Visual Studio 14.0/Common7/IDE/devenv.exe" ScriptServices.sln /Clean
-    EOH
-    cwd src_dir
-end
-
 execute "restore-nuget-packages" do
     command "#{Chef::Config[:file_cache_path]}\\nuget.exe restore"
     cwd src_dir


### PR DESCRIPTION
These changes make the `build-cookbook` build the solution with MSBuild instead of Visual Studio.
A log file is generated as before but has a new name, `ScriptServices.build.log` - this is so that the cookbook can be made to build several solutions if required.